### PR TITLE
Fix minor bug that made babel erroneously process app.json heroku config

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -9,7 +9,7 @@ const HtmlWebpackPluginConfig = new HtmlWebpackPlugin({
 })
 
 const PATHS = {
-  app: path.join(__dirname, 'app'),
+  app: path.join(__dirname, 'app/'),
   build: path.join(__dirname, 'dist'),
 }
 


### PR DESCRIPTION
This was a little confusing, the site was failing to deploy review apps on heroku, and I ended up tracking it down to whenever an app.json file existed (which is required), then react would fail to work.

changing the app dir from `app` to `src` also worked, but this (while arcane) treaded a little more lightly.

I would recommend we change from app to src so that this subtle thing doesn't bite more people.