### PR TITLE
Remove explicit reference to node version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "engines": {
-    "node": "6.3.1"
-  },
   "scripts": {
     "start": "webpack-dev-server",
     "build": "webpack -p --config ./webpack.config.babel.js --progress"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": "8.9.1"
+  },
   "scripts": {
     "start": "webpack-dev-server",
     "build": "webpack -p --config ./webpack.config.babel.js --progress"


### PR DESCRIPTION
This was referencing an older version of node for the engine, which was causing build errors. [Removing it entirely since it's optional](https://docs.npmjs.com/files/package.json#engines)