### PR TITLE
update wording to `[role] at [org]` from `[role], [org]`

### DIFF
--- a/app/pages/Home/components/SpeakerCard.js
+++ b/app/pages/Home/components/SpeakerCard.js
@@ -2,9 +2,13 @@ import React, { PropTypes } from 'react';
 import StyledButton from 'appCommon/StyledButton';
 import css from '../styles.css';
 
-
-const SpeakerCard = ({speaker}) => {
-  const name = !!speaker.display_name ? speaker.display_name : speaker.email
+const SpeakerCard = ({ speaker }) => {
+  const name = !!speaker.display_name ? speaker.display_name : speaker.email;
+  const title =
+    speaker.position && speaker.organization
+      ? `${speaker.position} at ${speaker.organization}`
+      : `${speaker.position || 'Independent'}, ${speaker.organization ||
+          'No affiliation'}`;
 
   return (
     <div className={css.contentCard}>
@@ -13,14 +17,20 @@ const SpeakerCard = ({speaker}) => {
       </div>
       <div className={css.info}>
         <h3 className={css.name}>{name}</h3>
-        <p className={css.speakerTitle}>{`${speaker.position || 'Independent'}, ${speaker.organization || 'No affiliation'}`}</p>
+        <p className={css.speakerTitle}>{title}</p>
         <p className={css.speakerTags}>{speaker.topic_list}</p>
       </div>
       <div className="actions">
-        <StyledButton color="primary" label='View profile' href={`#/speaker/${speaker.id}`}>View profile</StyledButton>
+        <StyledButton
+          color="primary"
+          label="View profile"
+          href={`#/speaker/${speaker.id}`}
+        >
+          View profile
+        </StyledButton>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default SpeakerCard
+export default SpeakerCard;

--- a/app/pages/Home/components/SpeakerList.js
+++ b/app/pages/Home/components/SpeakerList.js
@@ -7,33 +7,31 @@ import SpeakerCard from './SpeakerCard';
 import StyledButton from 'appCommon/StyledButton';
 import css from '../styles.css';
 
-
 const SpeakerList = ({ speakers, endOfResults, loadMoreSpeakers }) => {
   const noResults = speakers.length === 0;
 
   if (noResults) {
-    return <div className={css.noResults}>No results</div>
+    return <div className={css.noResults}>No results</div>;
   }
 
   return (
     <div>
       <div className={css.speakersList}>
-        {
-          speakers.map((speaker, index) => (
-            <SpeakerCard speaker={speaker} key={index} />
-          ))
-        }
+        {speakers.map((speaker, index) => (
+          <SpeakerCard speaker={speaker} key={speaker.id} />
+        ))}
       </div>
-      {
-        !endOfResults &&
+      {!endOfResults && (
         <Grid container justify={'center'}>
           <Grid item>
-            <StyledButton color="secondary" onClick={loadMoreSpeakers}>Load more speakers</StyledButton>
+            <StyledButton color="secondary" onClick={loadMoreSpeakers}>
+              Load more speakers
+            </StyledButton>
           </Grid>
         </Grid>
-      }
+      )}
     </div>
-  )
-}
+  );
+};
 
-export default SpeakerList
+export default SpeakerList;


### PR DESCRIPTION
closes #85 

examples of a profile that has both a role and an organization vs one that has neither:

![image](https://user-images.githubusercontent.com/23535291/37572922-a9012790-2ae8-11e8-8ca8-79c12ec7275d.png)

note: I also updated the speaker list to use speaker.id as the key rather than index - the other changes to that file are all Prettier changes