### PR TITLE
Update the topic in the heading above the speaker list after searching topic - fixes #76

### DIFF
--- a/app/pages/Home/Home.js
+++ b/app/pages/Home/Home.js
@@ -24,8 +24,14 @@ const searchParamsToSpeakerIdentity = ({ poc, woman }) => {
   }
 };
 
-const Home = props => {
-  const searchParams = props.searchParams;
+const Home = ({
+  searchParams,
+  locations,
+  speakers,
+  endOfResults,
+  loadMoreSpeakers,
+}) => {
+  const searchQuery = searchParams.q ? `'${searchParams.q}'` : 'all topics';
   const location = searchParams.location
     ? searchParams.location.city
     : 'all cities';
@@ -39,16 +45,16 @@ const Home = props => {
       <Grid item xs={8}>
         <Grid container>
           <Grid item xs={12} md={3}>
-            <Sidebar locations={props.locations} />
+            <Sidebar locations={locations} />
           </Grid>
           <Grid item xs={12} md={9}>
             <div
               className={css.contentTitles}
-            >{`${speakerIdentity} in ${location} for all topics`}</div>
+            >{`${speakerIdentity} in ${location} for ${searchQuery}`}</div>
             <SpeakerList
-              speakers={props.speakers}
-              endOfResults={props.endOfResults}
-              loadMoreSpeakers={props.loadMoreSpeakers}
+              speakers={speakers}
+              endOfResults={endOfResults}
+              loadMoreSpeakers={loadMoreSpeakers}
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
- When there is a topic search query, heading displays the query, otherwise refers to "all topics"
- Some formatting updates (from project prettier settings)
- Let me know if there are some styling changes required (if the query term should be distinguished)

<img width="911" alt="screen shot 2018-03-18 at 10 41 37 pm" src="https://user-images.githubusercontent.com/5035757/37575465-b1553e30-2afd-11e8-97a6-b2d9932e2545.png">
No topic query

<img width="883" alt="screen shot 2018-03-18 at 10 41 29 pm" src="https://user-images.githubusercontent.com/5035757/37575468-b3e4db38-2afd-11e8-8e9f-979a4a480045.png">
With topic query

Fixes #76 