### PR TITLE
Addition/add load spinners to front page

### DIFF
--- a/app/helpers/constants.js
+++ b/app/helpers/constants.js
@@ -37,7 +37,7 @@ export const IDENTITIES = [
 ];
 
 export const MAXIMUM_IMAGE_SIZE = 2 * 1024 * 1024; //less than 2MB in bytes
-export const DEFAULT_SPEAKER_LIMIT = 2;
+export const DEFAULT_SPEAKER_LIMIT = 20;
 export const VALID_PARAMS = [
   'location',
   'poc',

--- a/app/helpers/constants.js
+++ b/app/helpers/constants.js
@@ -37,7 +37,7 @@ export const IDENTITIES = [
 ];
 
 export const MAXIMUM_IMAGE_SIZE = 2 * 1024 * 1024; //less than 2MB in bytes
-export const DEFAULT_SPEAKER_LIMIT = 20;
+export const DEFAULT_SPEAKER_LIMIT = 2;
 export const VALID_PARAMS = [
   'location',
   'poc',

--- a/app/pages/Home/Home.js
+++ b/app/pages/Home/Home.js
@@ -34,6 +34,8 @@ const Home = ({
   speakers,
   endOfResults,
   loadMoreSpeakers,
+  isLoading,
+  isLoadingMore,
 }) => {
   const searchQuery = searchParams.q ? `'${searchParams.q}'` : 'all topics';
   const locationObj = find(locations, { id: parseInt(searchParams.location) })
@@ -68,6 +70,8 @@ const Home = ({
               speakers={speakers}
               endOfResults={endOfResults}
               loadMoreSpeakers={loadMoreSpeakers}
+              isLoading={isLoading}
+              isLoadingMore={isLoadingMore}
             />
           </Grid>
         </Grid>
@@ -118,6 +122,8 @@ const mapStateToProps = state => {
     locations: state.location.locations,
     searchParams: state.speaker.searchParams,
     endOfResults: state.speaker.endOfResults,
+    isLoading: state.speaker.isLoading,
+    isLoadingMore: state.speaker.isLoadingMore,
   };
 };
 

--- a/app/pages/Home/Home.js
+++ b/app/pages/Home/Home.js
@@ -35,7 +35,6 @@ const Home = ({
   endOfResults,
   loadMoreSpeakers,
   isLoading,
-  isLoadingMore,
 }) => {
   const searchQuery = searchParams.q ? `'${searchParams.q}'` : 'all topics';
   const locationObj = find(locations, { id: parseInt(searchParams.location) })
@@ -71,7 +70,6 @@ const Home = ({
               endOfResults={endOfResults}
               loadMoreSpeakers={loadMoreSpeakers}
               isLoading={isLoading}
-              isLoadingMore={isLoadingMore}
             />
           </Grid>
         </Grid>
@@ -123,7 +121,6 @@ const mapStateToProps = state => {
     searchParams: state.speaker.searchParams,
     endOfResults: state.speaker.endOfResults,
     isLoading: state.speaker.isLoading,
-    isLoadingMore: state.speaker.isLoadingMore,
   };
 };
 

--- a/app/pages/Home/components/SpeakerList.js
+++ b/app/pages/Home/components/SpeakerList.js
@@ -1,15 +1,18 @@
 // NPM
 import React, { PropTypes } from 'react';
 import Grid from 'material-ui/Grid';
+import ReactLoading from 'react-loading';
 
 // APP
 import SpeakerCard from './SpeakerCard';
 import StyledButton from 'appCommon/StyledButton';
 import css from '../styles.css';
 
-const SpeakerList = ({ speakers, endOfResults, loadMoreSpeakers }) => {
+const SpeakerList = ({ speakers, endOfResults, loadMoreSpeakers, isLoading, isLoadingMore }) => {
   const noResults = speakers.length === 0;
-
+  if (isLoading) {
+    return <ReactLoading type="spinningBubbles" color="#E5E8F4" />;
+  }
   if (noResults) {
     return <div className={css.noResults}>No results</div>;
   }
@@ -24,9 +27,10 @@ const SpeakerList = ({ speakers, endOfResults, loadMoreSpeakers }) => {
       {!endOfResults && (
         <Grid container justify={'center'} spacing={0}>
           <Grid item>
+          {isLoadingMore ? <ReactLoading type="spinningBubbles" color="#E5E8F4" /> :
             <StyledButton color="secondary" onClick={loadMoreSpeakers} className={css.loadMoreButton}>
               Load more speakers
-            </StyledButton>
+            </StyledButton>}
           </Grid>
         </Grid>
       )}

--- a/app/pages/Home/components/SpeakerList.js
+++ b/app/pages/Home/components/SpeakerList.js
@@ -8,12 +8,13 @@ import SpeakerCard from './SpeakerCard';
 import StyledButton from 'appCommon/StyledButton';
 import css from '../styles.css';
 
-const SpeakerList = ({ speakers, endOfResults, loadMoreSpeakers, isLoading, isLoadingMore }) => {
+const SpeakerList = ({ speakers, endOfResults, loadMoreSpeakers, isLoading }) => {
   const noResults = speakers.length === 0;
-  if (isLoading) {
+  if (isLoading && noResults) {
+    console.log('initial load')
     return <ReactLoading type="spinningBubbles" color="#E5E8F4" />;
   }
-  if (noResults) {
+  if (!isLoading && noResults) {
     return <div className={css.noResults}>No results</div>;
   }
 
@@ -27,10 +28,9 @@ const SpeakerList = ({ speakers, endOfResults, loadMoreSpeakers, isLoading, isLo
       {!endOfResults && (
         <Grid container justify={'center'} spacing={0}>
           <Grid item>
-          {isLoadingMore ? <ReactLoading type="spinningBubbles" color="#E5E8F4" /> :
             <StyledButton color="secondary" onClick={loadMoreSpeakers} className={css.loadMoreButton}>
-              Load more speakers
-            </StyledButton>}
+              {isLoading ? 'Loading...' : 'Load more speakers'}
+            </StyledButton>
           </Grid>
         </Grid>
       )}

--- a/app/redux/modules/speaker.js
+++ b/app/redux/modules/speaker.js
@@ -20,10 +20,15 @@ const MODULE_NAME = 'SPEAKER';
 const GET_SPEAKER = `${MODULE_NAME}/GET_SPEAKER`;
 const UPDATE_SPEAKER = `${MODULE_NAME}/UPDATE_SPEAKER`;
 const UPDATE_SPEAKERS = `${MODULE_NAME}/UPDATE_SPEAKERS`;
+const UPDATE_SPEAKERS_START = `${MODULE_NAME}/UPDATE_SPEAKERS_START`;
 const UPDATE_SEARCH_PARAMS = `${MODULE_NAME}/UPDATE_SEARCH_PARAMS`;
 const UPDATE_SELECTION = `${MODULE_NAME}/UPDATE_SELECTION`;
 
 // Sync Action
+export function updateSpeakersStart(append) {
+  return { type: UPDATE_SPEAKERS_START, append };
+}
+
 export function updateSpeakers(results, append) {
   return { type: UPDATE_SPEAKERS, results, append };
 }
@@ -42,6 +47,8 @@ export function fetchSpeakers(params = {}) {
   const queryStringforDisplay = generateQueryString({ params, display: true });
 
   return dispatch => {
+    dispatch(updateSpeakersStart(params.append));
+
     axios
       .get(`${BASE_URL_PATH}/api/v1/profiles?${queryStringforApi}`)
       .then(res => {
@@ -80,22 +87,37 @@ const INITIAL_STATE = {
   selectedLocation: null,
   selectedIdentity: IDENTITIES[0].label,
   speaker: null,
+  isLoading: false,
+  isLoadingMore: false,
 };
 
 export const reducer = (state = INITIAL_STATE, action) => {
   switch (action.type) {
+    case UPDATE_SPEAKERS_START: 
+      if (action.append) {
+        return {
+          ...state,
+          isLoadingMore: true,
+        }
+      }
+      return {
+        ...state,
+        isLoading: true,
+      };
     case UPDATE_SPEAKERS:
       if (action.append) {
         return {
           ...state,
           results: uniqBy(state.results.concat(action.results), 'id'),
           endOfResults: action.results.length < DEFAULT_SPEAKER_LIMIT,
+          isLoadingMore: false,
         };
       }
       return {
         ...state,
         results: uniqBy(action.results, 'id'),
         endOfResults: action.results.length < DEFAULT_SPEAKER_LIMIT,
+        isLoading: false,
       };
     case UPDATE_SPEAKER:
       return {

--- a/app/redux/modules/speaker.js
+++ b/app/redux/modules/speaker.js
@@ -88,18 +88,11 @@ const INITIAL_STATE = {
   selectedIdentity: IDENTITIES[0].label,
   speaker: null,
   isLoading: false,
-  isLoadingMore: false,
 };
 
 export const reducer = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case UPDATE_SPEAKERS_START: 
-      if (action.append) {
-        return {
-          ...state,
-          isLoadingMore: true,
-        }
-      }
       return {
         ...state,
         isLoading: true,
@@ -110,7 +103,7 @@ export const reducer = (state = INITIAL_STATE, action) => {
           ...state,
           results: uniqBy(state.results.concat(action.results), 'id'),
           endOfResults: action.results.length < DEFAULT_SPEAKER_LIMIT,
-          isLoadingMore: false,
+          isLoading: false,
         };
       }
       return {


### PR DESCRIPTION
When the front page loads the list of Speakers, it shows "no results" before showing the results. This could be a bad user experience. So I copied the loading spinner from the Speaker page to the home page for loading the speakers and loading more speakers (when user presses on "Load More Speakers"). There are currently two spinners: isLoading and isLoadingMore because isLoading is for an empty results list and isLoadingMore shows the spinner where the "Load More Speakers" button was.

One question is, do you want the load more spinner to replace the load more button, as it is now, or do you want the spinner below the button?

FOR TESTING:
You may need to set it to Slow 3G mode to see the spinner working and it takes a few seconds before it shows. Also, in the constants.js file from App>helpers, you'll need to set the speakers limit to 1 or 2, so the load more button shows up. 